### PR TITLE
feat: sort links by github action #82

### DIFF
--- a/.github/workflows/sort.yml
+++ b/.github/workflows/sort.yml
@@ -1,0 +1,13 @@
+on: [push]
+
+jobs:
+  table:
+    runs-on: ubuntu-latest
+    name: Sort Links
+    steps:
+    - uses: actions/checkout@v2
+    - name: Read/Write data into README
+      uses: allanregush/gh-actions-sort-markdown-links@v0.0.1
+      with:
+        md-file-path: 'README.md'
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Questions can be asked by raising an `Issue`.
 - Hurray! You successfully made a contribution
 
 ## Hacktoberfest community
-
+<!--START_SECTION:links-->
 - [Savio Martin](https://github.com/saviomartin)
 - [Aakarsh Teja](https://github.com/aakarshteja)
 - [Aarul Mishra](https://github.com/Aarul14)
@@ -199,3 +199,4 @@ Questions can be asked by raising an `Issue`.
 - [Victory Chiamaka Wekwa](https://github.com/VictoryWekwa)
 - [Stephen Mount (@stemount)](https://github.com/stemount)
 - [Asharib Ahmed](https://github.com/Asharib90)
+<!--END_SECTION:links-->


### PR DESCRIPTION
closes #82 

This pull request will allow markdown links to be sorted by a github action.